### PR TITLE
build(deps): use youtube_dl as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = third-party/repo-scripts
 	url = https://github.com/xbmc/repo-scripts.git
 	branch = matrix
+[submodule "third-party/youtube-dl"]
+	path = third-party/youtube-dl
+	url = https://github.com/ytdl-org/youtube-dl.git
+	branch = master

--- a/addon.yaml
+++ b/addon.yaml
@@ -33,4 +33,3 @@ addon:
       - addon: "xbmc.python"
         version: "3.0.1"
       - addon: "script.module.requests"
-      - addon: "script.module.youtube.dl"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+./third-party/youtube-dl


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use youtube-dl as a submodule in attempt to fix the `isatty` attribute error when logging youtube-dl stdout/stderr messages.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #17 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
