### PR TITLE
fix: import youtube_dl from YoutubeDLWrapper

### DIFF
--- a/addon.yaml
+++ b/addon.yaml
@@ -32,5 +32,6 @@ addon:
     import:
       - addon: "xbmc.python"
         version: "3.0.1"
+      - addon: "script.module.kodi-six"  # this is a dependency of youtube-dl, but we need to put it here for CI tests
       - addon: "script.module.requests"
       - addon: "script.module.youtube.dl"

--- a/scripts/bootstrap_kodi.py
+++ b/scripts/bootstrap_kodi.py
@@ -22,20 +22,34 @@ def get_modules():
 
 
 def bootstrap_modules():
+    lib_dirs = (
+        'lib',
+        'libs',
+    )
+
     required_modules = get_modules()
 
     # check if the required modules are installed, only for unit testing
     for m in required_modules:
         module_found = False
         for p in sys.path:
-            if p.endswith(os.path.join(m, 'lib')):
-                module_found = True
-                break
-        if not module_found:
-            dev_path = os.path.join(root_dir, 'third-party', 'repo-scripts', m, 'lib')
-            if os.path.isdir(dev_path):
-                print(f"Adding dev path: {dev_path}")
-                sys.path.insert(0, dev_path)
+            if not module_found:
+                for lib_dir in lib_dirs:
+                    if p.endswith(os.path.join(m, lib_dir)):
+                        module_found = True
+                        break  # break out of lib_dirs loop
             else:
+                break  # module already found, break out of sys.path loop
+        if not module_found:
+
+            for lib_dir in lib_dirs:
+                dev_path = os.path.join(root_dir, 'third-party', 'repo-scripts', m, lib_dir)
+                if os.path.isdir(dev_path):
+                    print(f"Adding dev path: {dev_path}")
+                    sys.path.insert(0, dev_path)
+                    module_found = True
+                    break
+
+            if not module_found:
                 print(f"Module not found: {m}")
                 raise ModuleNotFoundError(f"Module not found: {m}")

--- a/src/themerr/youtube.py
+++ b/src/themerr/youtube.py
@@ -2,7 +2,10 @@
 from typing import Optional
 
 # lib imports
-import youtube_dl
+try:
+    from YoutubeDLWrapper import youtube_dl  # importing from wrapper applies kodi patches
+except TypeError:
+    import youtube_dl  # patches fail when building docs
 
 # local imports
 from . import logger


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Kodi has several patches applied for YouTube-DL in the `YoutubeDLWrapper` which were not being applied when importing `youtube_dl` directly. Importing from the wrapper will fix any of these various issues.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #17 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
