### PR TITLE
fix: generate kodi_id for cases where a list item has no DBID

### DIFF
--- a/src/themerr/player.py
+++ b/src/themerr/player.py
@@ -23,7 +23,7 @@ class Player(xbmc.Player):
         True if a theme is currently playing, False otherwise.
     theme_is_playing_for : int
         The number of seconds the theme has been playing for.
-    theme_playing_kodi_id : Optional[int]
+    theme_playing_kodi_id : Optional[str]
         The Kodi ID of the theme currently playing.
     theme_playing_url : Optional[str]
         The URL of the theme currently playing.
@@ -32,7 +32,7 @@ class Player(xbmc.Player):
     -------
     ytdl_extract_url(url: str) -> Optional[str]
         Extract the audio URL from a YouTube URL.
-    play_url(url: str, kodi_id: int, windowed: bool = False)
+    play_url(url: str, kodi_id: str, windowed: bool = False)
         Play a YouTube URL.
     stop()
         Stop playback.
@@ -59,7 +59,7 @@ class Player(xbmc.Player):
     def play_url(
             self,
             url: str,
-            kodi_id: int,
+            kodi_id: str,
             windowed: bool = False,
     ):
         """
@@ -71,7 +71,7 @@ class Player(xbmc.Player):
         ----------
         url : str
             The url to play.
-        kodi_id : int
+        kodi_id : str
             The Kodi ID of the item.
         windowed : bool
             True to play in a window, False otherwise.
@@ -79,7 +79,7 @@ class Player(xbmc.Player):
         Examples
         --------
         >>> player = Player()
-        >>> player.play_url(url="https://www.youtube.com/watch?v=dQw4w9WgXcQ", kodi_id=1)
+        >>> player.play_url(url="https://www.youtube.com/watch?v=dQw4w9WgXcQ", kodi_id='tmdb_1')
         """
         playable_url = self.ytdl_extract_url(url=url)
         if playable_url:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Video addons do not have a DBID. This PR modifies Themerr's behavior to use a generated `kodi_id` instead of using the DBID.

Todo:
- [x] Update unit tests


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #18 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
