### PR TITLE
ci: remove duplicated localization step

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,11 +69,6 @@ jobs:
           python -m pip install -r requirements-dev.txt
           python -m pip install -r requirements.txt
 
-      - name: Compile Locale Translations
-        shell: bash
-        run: |
-          python -m scripts.locale --compile
-
       - name: Build
         shell: bash
         env:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -85,7 +85,7 @@ def compile_localizations():
     """
     # kodi using po files for localization, no need to compile to mo
     subprocess.run(
-        args=[sys.executable, '-m', 'scripts.locale', '--update'],
+        args=[sys.executable, '-m', 'scripts.locale', '--update', '--compile'],
     )
 
     # locale directories


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The localization compile step is unnecessary in the CI since Kodi doesn't not use `mo` files for translation... and the localization update is already part of the build module.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
