### PR TITLE
build: obtain xbmc addon versions dynamically

### DIFF
--- a/addon.yaml
+++ b/addon.yaml
@@ -31,7 +31,6 @@ addon:
   requires:
     import:
       - addon: "xbmc.python"
-        version: "3.0.1"
       - addon: "script.module.kodi-six"  # this is a dependency of youtube-dl, but we need to put it here for CI tests
       - addon: "script.module.requests"
       - addon: "script.module.youtube.dl"

--- a/scripts/addon_yaml_to_xml.py
+++ b/scripts/addon_yaml_to_xml.py
@@ -3,11 +3,9 @@ import argparse
 import os
 
 # lib imports
+from kodi_addon_checker.check_dependencies import VERSION_ATTRB as xbmc_versions
 from lxml import etree
 import yaml
-
-# constants
-xbmc_python_version = '3.0.1'  # todo: obtain this dynamically
 
 
 def handle_asset_elements(
@@ -37,8 +35,9 @@ def yaml_to_xml_lxml(yaml_file: str) -> str:
             # if the version is specified in yaml, don't look it up
             # this allows pinning a requirement to a specific version
             continue
-        if requirement['addon'] == 'xbmc.python':
-            requirement['version'] = xbmc_python_version
+        if requirement['addon'].startswith('xbmc.'):
+            requirement['version'] = xbmc_versions[requirement['addon']][os.getenv(
+                'KODI_BRANCH', 'Nexus').lower()]['advised']
         elif requirement['addon'].startswith('script.module.'):
             requirement_xml = os.path.join(
                 os.getcwd(), 'third-party', 'repo-scripts', requirement['addon'], 'addon.xml')


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The advised version of xbmc addons will now be extracted from the kodi addon checker.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
