### PR TITLE
refactor: remove unused process_movie method

### DIFF
--- a/src/themerr/gui.py
+++ b/src/themerr/gui.py
@@ -1,7 +1,7 @@
 # standard imports
 from datetime import datetime
 import json
-from typing import Dict, List, Optional, Set, Union
+from typing import List, Optional, Set, Union
 
 # lib imports
 import requests
@@ -258,54 +258,6 @@ class Window:
             )
 
             return youtube_url
-
-    def _process_movie(self, dbid: int) -> Dict[str, Optional[Union[str, int]]]:
-        """
-        Generate a dictionary of IDs from a given Kodi ID, for a movie.
-
-        This method takes a Kodi ID and returns a dictionary of IDs.
-        This method is no longer used, and may be removed in the future.
-
-        Parameters
-        ----------
-        dbid : int
-            The Kodi DBID to process.
-
-        Returns
-        -------
-        Dict[str, Optional[Union[str, int]]]
-            A dictionary of IDs.
-
-        Examples
-        --------
-        >>> window = Window()
-        >>> window._process_movie(kodi_id=1)
-        {'themoviedb': ..., 'imdb': ...}
-        """
-        # query the kodi database to get tmdb and imdb unique ids
-        rpc_query = {
-            "jsonrpc": "2.0",
-            "method": "VideoLibrary.GetMovieDetails",
-            "params": {
-                "movieid": int(dbid),
-                "properties": [
-                    "imdbnumber",
-                    "uniqueid",
-                ],
-            },
-            "id": "libMovies",
-        }
-        rpc_response = xbmc.executeJSONRPC(json.dumps(rpc_query))
-        json_response = json.loads(rpc_response)
-        self.log.debug(f"JSON response: {json_response}")
-
-        # get the supported ids
-        ids = {
-            'themoviedb': json_response['result']['moviedetails']['uniqueid'].get('tmdb'),
-            'imdb': json_response['result']['moviedetails']['uniqueid'].get('imdb'),
-        }
-        self.log.debug(f"IDs: {ids}")
-        return ids
 
     def find_youtube_url(self, kodi_id: str, db_type: str) -> Optional[str]:
         """


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR removes the unused `_process_movie` method. I wanted to have this in a separate PR, instead of #22 so it will be easier to reference the json rpc method if we need to re-implement something similar later.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
