### PR TITLE
build(deps): add ability to depend on official addons

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ Kodistubs==20.0.1  # docs: https://romanvm.github.io/Kodistubs
 pytest==7.4.4
 pytest-cov==4.1.0
 PyYAML==6.0.1
+requests==2.31.0
 rstcheck==6.2.0
 Sphinx==7.1.2
 sphinx-copybutton==0.5.2

--- a/scripts/addon_yaml_to_xml.py
+++ b/scripts/addon_yaml_to_xml.py
@@ -5,7 +5,11 @@ import os
 # lib imports
 from kodi_addon_checker.check_dependencies import VERSION_ATTRB as xbmc_versions
 from lxml import etree
+import requests
 import yaml
+
+# global vars
+kodi_branch = os.getenv('KODI_BRANCH', 'Nexus').lower()
 
 
 def handle_asset_elements(
@@ -21,6 +25,16 @@ def handle_asset_elements(
             etree.SubElement(parent, key).text = value
 
 
+def get_branch_plugins():
+    url = f'http://mirrors.kodi.tv/addons/{kodi_branch}/addons.xml'
+    response = requests.get(url)
+
+    if response.status_code != 200:
+        raise Exception(f'Failed to get {url}')
+
+    return etree.fromstring(response.content)
+
+
 def yaml_to_xml_lxml(yaml_file: str) -> str:
     # Load YAML file
     with open(yaml_file, 'r') as file:
@@ -30,18 +44,32 @@ def yaml_to_xml_lxml(yaml_file: str) -> str:
     build_version = os.getenv('BUILD_VERSION')
     if build_version:  # update version if building from CI
         data['addon']['version'] = build_version
+
+    branch_addons_xml = None
+
     for requirement in data['addon']['requires']['import']:
         if requirement.get('version'):
             # if the version is specified in yaml, don't look it up
             # this allows pinning a requirement to a specific version
             continue
+
+        requirement_xml = None
+
         if requirement['addon'].startswith('xbmc.'):
-            requirement['version'] = xbmc_versions[requirement['addon']][os.getenv(
-                'KODI_BRANCH', 'Nexus').lower()]['advised']
+            requirement['version'] = xbmc_versions[requirement['addon']][kodi_branch]['advised']
         elif requirement['addon'].startswith('script.module.'):
             requirement_xml = os.path.join(
                 os.getcwd(), 'third-party', 'repo-scripts', requirement['addon'], 'addon.xml')
+        else:
+            if not branch_addons_xml:
+                branch_addons_xml = get_branch_plugins()  # only get the branch addons.xml if we need it
 
+            # get the requirement version from the branch addons.xml
+            addon = branch_addons_xml.xpath(f'//addon[@id="{requirement["addon"]}"]')
+            version = addon[0].attrib['version']
+            requirement['version'] = version
+
+        if requirement_xml:
             # get the version property out of the addon tag
             with open(requirement_xml, 'r', encoding='utf-8') as file:
                 requirement_data = etree.parse(file)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
While developing #46, I was investigating using other addons to help get the tmdb id for seasons/episodes. It didn't pan out, but it required the ability to specify these addons in the `addon.xml`. This PR adds support for such cases.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
