### PR TITLE
docs(conf): use already defined python_version variable

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,7 +121,7 @@ suppress_warnings = ["epub.unknown_project_files"]
 python_version = f'{sys.version_info.major}.{sys.version_info.minor}'
 
 intersphinx_mapping = {
-    'python': (f'https://docs.python.org/{sys.version_info.major}.{sys.version_info.minor}', None),
+    'python': (f'https://docs.python.org/{python_version}', None),
     'xbmc': ('https://romanvm.github.io/Kodistubs', None),
 }
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use already defined `python_version` variable during docs build.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
